### PR TITLE
[Feature] Use embeddings for PBM

### DIFF
--- a/config/model/pbm.yaml
+++ b/config/model/pbm.yaml
@@ -1,10 +1,7 @@
 defaults:
   - base
 
-_target_: src.models.TwoTowerModel
+_target_: src.models.PositionBasedModel
 bias_layers: [ 512, 256, 128 ]
 bias_dropouts: [ 0, 0.1, 0.1 ]
-bias_embeddings:
-  position: 50
-
 tower_combination: ADDITIVE

--- a/config/model/two-towers.yaml
+++ b/config/model/two-towers.yaml
@@ -4,11 +4,4 @@ defaults:
 _target_: src.models.TwoTowerModel
 bias_layers: [ 512, 256, 128 ]
 bias_dropouts: [ 0, 0.1, 0.1 ]
-bias_embeddings:
-  position: 50
-  media_type: 10_001
-  displayed_time: 18
-  serp_height: 18
-  slipoff_count_after_click: 11
-
 tower_combination: ADDITIVE


### PR DESCRIPTION
During local testing, I found that a two tower model just using positional embeddings (e.g., 8 dims for each) works better than the PBM implementation with a single parameter per rank. I'm refactoring the two tower model to take a dict of bias features, thus the PBM becomes a special case of the two tower model.

Below is a screenshot of PBMs vs Two Tower models using only position in simulation:
<img width="1413" alt="Screenshot 2023-11-15 at 13 50 39" src="https://github.com/philipphager/ultr-reproducibility/assets/9155371/3b3b3e74-6667-4de8-84f4-ab714d61fc5f">


