### PR TITLE
[Checkpointing] Flax legacy API

### DIFF
--- a/app/utils/model.py
+++ b/app/utils/model.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 
-from orbax.checkpoint import PyTreeCheckpointer
+from flax.training import checkpoints
 
 
 def load_state(path: Path, name: str = "best_state"):
-    checkpointer = PyTreeCheckpointer()
-    return checkpointer.restore(path.resolve() / name)
+    return checkpoints.restore_checkpoint(path.resolve() / name, target=None)

--- a/src/util.py
+++ b/src/util.py
@@ -4,9 +4,8 @@ from typing import Dict, List
 import jax
 import numpy as np
 import pandas as pd
-from flax.training import early_stopping
+from flax.training import early_stopping, checkpoints
 from jax import Array
-from orbax.checkpoint import PyTreeCheckpointer
 
 
 class EarlyStopping:
@@ -62,5 +61,4 @@ def dict_to_numpy(_dict: Dict[str, Array]) -> Dict[str, np.ndarray]:
 
 
 def save_state(state, directory: Path, name: str = "best_state"):
-    checkpointer = PyTreeCheckpointer()
-    checkpointer.save(directory.resolve() / name, state, force=True)
+    checkpoints.save_checkpoint(directory / name, state, step=0, overwrite=True)


### PR DESCRIPTION
For some reason Orbax is completely broken and complains for me that I cannot load checkpoints trained on cuda locally on CPU. I couldn't figure out the error and wouldn't like to invest more time in this. The legacy flax API uses Orbax in the background, and this change works for me without a problem.

@RomDeffayet can you checkout this branch (some time in the coming days, not urgent) and see if you can still load checkpoints? If so, I'd propose to merge this change.